### PR TITLE
change TokenType enum to incorporate self knowledge of being a link type token

### DIFF
--- a/lib/src/models/token.dart
+++ b/lib/src/models/token.dart
@@ -6,19 +6,19 @@ enum TokenType {
   text,
 
   /// Bold and italic formatting marker: '***' or '___'
-  boldItalicMarker,
+  boldItalicMarker(isFormattingMarker:true),
 
   /// Bold formatting marker: '**' or '__'
-  boldMarker,
+  boldMarker(isFormattingMarker:true),
 
   /// Italic formatting marker: '*' or '_'
-  italicMarker,
+  italicMarker(isFormattingMarker:true),
 
   /// Strikethrough formatting marker: '~~'
-  strikeMarker,
+  strikeMarker(isFormattingMarker: true),
 
   /// Inline code formatting marker: '`'
-  codeMarker,
+  codeMarker(isFormattingMarker:true),
 
   /// Opening square bracket for link: '['
   linkStart(isLinkToken:true),
@@ -36,7 +36,10 @@ enum TokenType {
   linkEnd(isLinkToken:true),
   ;
 
-  const TokenType( {this.isLinkToken=false} );
+  const TokenType( {this.isFormattingMarker=false, this.isLinkToken=false} );
+
+  /// Indicates whether this token type is standard formatting marker.
+  final bool isFormattingMarker;
 
   /// Indicates whether this token type is part of a link.
   final bool isLinkToken;

--- a/lib/src/models/token.dart
+++ b/lib/src/models/token.dart
@@ -21,19 +21,25 @@ enum TokenType {
   codeMarker,
 
   /// Opening square bracket for link: '['
-  linkStart,
+  linkStart(isLinkToken:true),
 
   /// Text content to be displayed for a link
-  linkText,
+  linkText(isLinkToken:true),
 
   /// Closing square bracket followed by opening parenthesis: ']('
-  linkSeparator,
+  linkSeparator(isLinkToken:true),
 
   /// URL content of a link
-  linkUrl,
+  linkUrl(isLinkToken:true),
 
   /// Closing parenthesis for link: ')'
-  linkEnd,
+  linkEnd(isLinkToken:true),
+  ;
+
+  const TokenType( {this.isLinkToken=false} );
+
+  /// Indicates whether this token type is part of a link.
+  final bool isLinkToken;
 }
 
 /// Represents a single token in the parsing process.

--- a/lib/src/parsing/components/pairing_resolver.dart
+++ b/lib/src/parsing/components/pairing_resolver.dart
@@ -51,7 +51,7 @@ class PairingResolver {
       if (token.type == TokenType.text) continue;
 
       // Skip link-related tokens as they're handled separately
-      if (_isLinkToken(token.type)) {
+      if (token.type.isLinkToken) {
         continue;
       }
 
@@ -73,17 +73,4 @@ class PairingResolver {
     }
   }
 
-  /// Checks if a token type is link-related.
-  ///
-  /// Link tokens are handled differently from formatting tokens.
-  ///
-  /// @param type The token type to check
-  /// @return True if the token is link-related, false otherwise
-  static bool _isLinkToken(TokenType type) {
-    return type == TokenType.linkStart ||
-        type == TokenType.linkText ||
-        type == TokenType.linkSeparator ||
-        type == TokenType.linkUrl ||
-        type == TokenType.linkEnd;
-  }
 }

--- a/lib/src/parsing/parser.dart
+++ b/lib/src/parsing/parser.dart
@@ -133,7 +133,7 @@ class TextfParser {
         }
       }
       // Is it a formatting marker (bold, italic, code, strike, etc.)?
-      else if (_isFormattingMarker(token.type)) {
+      else if (token.type.isFormattingMarker) {
         // Check if this specific marker instance is part of a *valid* pair.
         if (state.matchingPairs.containsKey(i)) {
           // Yes, it's part of a valid pair (either opening or closing).
@@ -163,15 +163,6 @@ class TextfParser {
     state.flushText(context);
 
     return state.spans;
-  }
-
-  /// Helper to check if a token type corresponds to a standard formatting marker.
-  bool _isFormattingMarker(TokenType type) {
-    return type == TokenType.boldMarker ||
-        type == TokenType.italicMarker ||
-        type == TokenType.boldItalicMarker ||
-        type == TokenType.strikeMarker ||
-        type == TokenType.codeMarker;
   }
 
   /// Debugging utility to view the tokenization and pairing process.


### PR DESCRIPTION
This PR takes advantage of Dart's enhanced enums to incorporate knowledge into each `TokenType` enum about whether it is a link token or formatting marker.
This allows the `PairingResolver` performance to be slightly improved because it eliminates the loop call and comparison of each `token.type` to one of the 5 possible link `TokenType`s.

It also allows the parser to eliminate the need to have a _isFormattingMarker() method and call/comparisons there.

This is just a simple change that I noticed when merging my optimizations to the parsing and tokenizing. (That PR is coming once I have the merge complete and tested).  