### PR TITLE
feat: add heading formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,19 @@ final controller = TextfEditingController();
 TextField(controller: controller)
 ```
 
+For headings in editable fields, disable forced strut height so bigger spans
+can own their line height:
+
+```dart
+final style = Theme.of(context).textTheme.bodyLarge!;
+
+TextField(
+  controller: controller,
+  style: style,
+  strutStyle: StrutStyle.fromTextStyle(style, forceStrutHeight: false),
+)
+```
+
 With initial content:
 
 ```dart

--- a/example/advanced/lib/main_scaling.dart
+++ b/example/advanced/lib/main_scaling.dart
@@ -183,6 +183,7 @@ class _EditorTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final style = TextStyle(fontSize: fontSize);
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
         textScaler: TextScaler.linear(textScaleFactor),
@@ -197,7 +198,11 @@ class _EditorTab extends StatelessWidget {
                 maxLines: null,
                 expands: true,
                 textAlignVertical: TextAlignVertical.top,
-                style: TextStyle(fontSize: fontSize),
+                strutStyle: StrutStyle.fromTextStyle(
+                  style,
+                  forceStrutHeight: false,
+                ),
+                style: style,
                 decoration: InputDecoration(
                   hintText: 'Type **bold**, *italic*, ^super^, ~sub~...',
                   border: const OutlineInputBorder(),

--- a/example/advanced/lib/screens/editing_controller_screen.dart
+++ b/example/advanced/lib/screens/editing_controller_screen.dart
@@ -28,7 +28,7 @@ class _EditingControllerScreenState extends State<EditingControllerScreen> {
     super.initState();
     _controller = TextfEditingController(
       text: '''
-🚀 **Welcome to Textf!**
+# Welcome to Textf! 🚀
 
 Edit this text to see live formatting in action:
 • **Bold**, *Italic* text and ***both***
@@ -104,6 +104,10 @@ Check out the [Documentation](https://pub.dev/packages/textf) for more details.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final inputStrutStyle = StrutStyle.fromTextStyle(
+      theme.textTheme.bodyLarge!,
+      forceStrutHeight: false,
+    );
     final brightness = theme.brightness;
     final themeIcon =
         brightness == Brightness.dark ? Icons.light_mode_outlined : Icons.dark_mode_outlined;
@@ -141,6 +145,7 @@ Check out the [Documentation](https://pub.dev/packages/textf) for more details.
           TextField(
             controller: _controller,
             maxLines: 10,
+            strutStyle: inputStrutStyle,
             decoration: InputDecoration(
               hintText: 'Type formatted text here...',
               border: const OutlineInputBorder(),
@@ -212,6 +217,7 @@ Check out the [Documentation](https://pub.dev/packages/textf) for more details.
                     '`styled code`',
               ),
               maxLines: 2,
+              strutStyle: inputStrutStyle,
               decoration: InputDecoration(
                 labelText: 'Custom styled',
                 border: const OutlineInputBorder(),
@@ -239,6 +245,7 @@ Check out the [Documentation](https://pub.dev/packages/textf) for more details.
               text: 'A **required** field with *formatted* hints',
             ),
             maxLines: 2,
+            strutStyle: inputStrutStyle,
             decoration: InputDecoration(
               labelText: 'Bio',
               helperText: 'Supports bold, italic, code, and more',
@@ -475,11 +482,16 @@ class _ChatDemo extends StatelessWidget {
                 Expanded(
                   child: TextField(
                     controller: controller,
+                    strutStyle: StrutStyle.fromTextStyle(
+                      theme.textTheme.bodyLarge!,
+                      forceStrutHeight: false,
+                    ),
                     decoration: const InputDecoration(
                       hintText: 'Type a **formatted** message...',
                       border: InputBorder.none,
                       contentPadding: EdgeInsets.symmetric(horizontal: 12),
                     ),
+                    style: theme.textTheme.bodyLarge,
                     onSubmitted: (_) => onSend(),
                   ),
                 ),
@@ -532,6 +544,10 @@ class _SideBySideComparisonState extends State<_SideBySideComparison> {
         TextField(
           controller: _comparisonController,
           maxLines: 2,
+          strutStyle: StrutStyle.fromTextStyle(
+            theme.textTheme.bodyLarge!,
+            forceStrutHeight: false,
+          ),
           decoration: InputDecoration(
             labelText: 'Editable (TextField)',
             border: const OutlineInputBorder(),

--- a/example/advanced/lib/screens/headings_screen.dart
+++ b/example/advanced/lib/screens/headings_screen.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:textf/textf.dart';
+
+import '../widgets/example_card.dart';
+
+class HeadingsScreen extends StatelessWidget {
+  const HeadingsScreen({
+    required this.toggleThemeMode,
+    super.key,
+  });
+  final VoidCallback toggleThemeMode;
+
+  @override
+  Widget build(BuildContext context) {
+    final Brightness currentBrightness = Theme.of(context).brightness;
+    final IconData themeIcon =
+        currentBrightness == Brightness.dark ? Icons.light_mode_outlined : Icons.dark_mode_outlined;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Headings'),
+        actions: [
+          IconButton(
+            icon: Icon(themeIcon),
+            tooltip: 'Toggle Theme',
+            onPressed: toggleThemeMode,
+          ),
+        ],
+      ),
+      body: SelectionArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: const [
+            ExampleCard(
+              title: 'All Six Levels',
+              description: "1–6 '#' at the start of a line; style scopes to the line's end",
+              code: r"Textf('# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\nbody')",
+              child: Textf(
+                '# Heading 1\n'
+                '## Heading 2\n'
+                '### Heading 3\n'
+                '#### Heading 4\n'
+                '##### Heading 5\n'
+                '###### Heading 6\n'
+                'Normal body text.',
+              ),
+            ),
+            SizedBox(height: 16),
+            ExampleCard(
+              title: 'Inline Formatting Nests',
+              description: 'Bold, italic, etc. compose inside a heading line',
+              code: "Textf('# Heading with **bold** and *italic*')",
+              child: Textf('# Heading with **bold** and *italic*'),
+            ),
+            SizedBox(height: 16),
+            ExampleCard(
+              title: 'Not a Heading Mid-Line',
+              description: "'#' only starts a heading at the beginning of a line",
+              code: "Textf('Use C# and #hashtags freely.')",
+              child: Textf('Use C# and #hashtags freely.'),
+            ),
+            SizedBox(height: 16),
+            ExampleCard(
+              title: 'Custom Heading Styles',
+              description: 'Override any level via TextfOptions h1Style–h6Style',
+              code: 'TextfOptions(h1Style: ..., h2Style: ..., child: Textf(...))',
+              child: TextfOptions(
+                h1Style: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w800,
+                  color: Colors.deepPurple,
+                ),
+                h2Style: TextStyle(fontSize: 24, color: Colors.purple),
+                child: Textf(
+                  '# Custom H1\n'
+                  '## Custom H2\n'
+                  'Default-styled body.',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/advanced/lib/screens/home_screen.dart
+++ b/example/advanced/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:textf/textf.dart';
 import 'basic_formatting_screen.dart';
 import 'complex_formatting_screen.dart';
 import 'editing_controller_screen.dart';
+import 'headings_screen.dart';
 import 'nested_formatting_screen.dart';
 import 'placeholder_example_screen.dart';
 import 'screenshot_screen.dart';
@@ -79,6 +80,19 @@ class HomeScreen extends StatelessWidget {
               ThemeExampleScreen(
                 // Pass down theme info
                 currentThemeMode: currentThemeMode,
+                toggleThemeMode: toggleThemeMode,
+              ),
+            ),
+            _buildExampleTile(
+              context,
+              const Textf(
+                '{new} Headings',
+                placeholders: {
+                  'new': badgeNew,
+                },
+              ),
+              const Text('ATX-style H1–H6 headings with # at line start'),
+              HeadingsScreen(
                 toggleThemeMode: toggleThemeMode,
               ),
             ),

--- a/example/basic/lib/main.dart
+++ b/example/basic/lib/main.dart
@@ -85,6 +85,55 @@ class ShowcaseScreen extends StatelessWidget {
             const SizedBox(height: 24),
 
             // ─────────────────────────────────────────────────────────────
+            // SECTION: Headings (H1–H6)
+            // ─────────────────────────────────────────────────────────────
+            _sectionHeader('Headings (H1 – H6)'),
+
+            // ATX-style headings: 1–6 '#' at the start of a line.
+            // The style scopes to the end of the line.
+            const Textf(
+              '# Heading Level 1\n'
+              '## Heading Level 2\n'
+              '### Heading Level 3\n'
+              '#### Heading Level 4\n'
+              '##### Heading Level 5\n'
+              '###### Heading Level 6\n'
+              'This line is normal body text again.',
+            ),
+
+            const SizedBox(height: 8),
+
+            // Inline formatting nests inside headings.
+            const Textf('# Heading with **bold** and *italic*'),
+
+            const SizedBox(height: 8),
+
+            // Mid-line '#' is NOT a heading — only a line-start run is.
+            const Textf('Use C# and #hashtags freely mid-line.'),
+
+            const SizedBox(height: 8),
+
+            // Override heading sizes per-level via TextfOptions.
+            const TextfOptions(
+              h1Style: TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.w800,
+                color: Colors.deepPurple,
+              ),
+              h2Style: TextStyle(
+                fontSize: 24,
+                color: Colors.purple,
+              ),
+              child: Textf(
+                '# Custom H1\n'
+                '## Custom H2\n'
+                'Default-styled body.',
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // ─────────────────────────────────────────────────────────────
             // SECTION 2: Superscript & Subscript
             // ─────────────────────────────────────────────────────────────
             _sectionHeader('2. Superscript & Subscript'),

--- a/example/textf_widgetbook/lib/use_cases/textf_editing_controller_use_case.dart
+++ b/example/textf_widgetbook/lib/use_cases/textf_editing_controller_use_case.dart
@@ -103,6 +103,10 @@ class _TextfEditingControllerUseCaseState extends State<TextfEditingControllerUs
       controller: _controller,
       maxLines: null,
       minLines: 4,
+      strutStyle: StrutStyle.fromTextStyle(
+        const TextStyle(fontSize: 16),
+        forceStrutHeight: false,
+      ),
       style: const TextStyle(fontSize: 16),
       decoration: const InputDecoration(
         border: OutlineInputBorder(),

--- a/lib/src/core/constants.dart
+++ b/lib/src/core/constants.dart
@@ -88,3 +88,8 @@ const int kLinkEndTokenOffset = 4;
 
 /// Carriage Return character \r (ASCII code 13)
 const int kCarriageReturn = 0x0D;
+
+/// Hash character # (ASCII code 35)
+///
+/// Used for ATX-style headings (`#` H1 .. `######` H6) at the start of a line.
+const int kHash = 0x23;

--- a/lib/src/core/default_styles.dart
+++ b/lib/src/core/default_styles.dart
@@ -45,6 +45,32 @@ class DefaultStyles {
   /// Default baseline offset factor for subscript (relative to font size).
   static const double subscriptBaselineFactor = 0.4; // Move down
 
+  /// Relative font-size multipliers for H1–H6.
+  static const List<double> headingFontSizeFactors = [
+    2.00, // h1
+    1.50, // h2
+    1.33, // h3
+    1.14, // h4
+    1.07, // h5
+    1.00, // h6
+  ];
+
+  /// Default heading style for ATX headings (`# H1` .. `###### H6`).
+  ///
+  /// Scales the base font size by [headingFontSizeFactors] and applies bold
+  /// weight. Used as a fallback when no
+  /// `h{n}Style` is provided via TextfOptions.
+  static TextStyle headingStyle(int level, TextStyle baseStyle) {
+    final int index = (level - 1).clamp(0, headingFontSizeFactors.length - 1);
+    final double factor = headingFontSizeFactors[index];
+    final double baseSize = baseStyle.fontSize ?? defaultFontSize;
+    return baseStyle.copyWith(
+      fontSize: baseSize * factor,
+      fontWeight: baseStyle.fontWeight ?? FontWeight.bold,
+      height: 1.2,
+    );
+  }
+
   /// Applies default bold formatting (`**bold**` or `__bold__`) to a base style.
   /// Used as a fallback by TextfStyleResolver if no `boldStyle` is found via TextfOptions.
   static TextStyle boldStyle(TextStyle baseStyle) {

--- a/lib/src/core/formatting_utils.dart
+++ b/lib/src/core/formatting_utils.dart
@@ -28,7 +28,8 @@ class FormattingUtils {
           char == kPlus ||
           char == kEscape ||
           char == kOpenBracket ||
-          char == kOpenBrace) {
+          char == kOpenBrace ||
+          char == kHash) {
         return true;
       }
     }
@@ -113,6 +114,10 @@ class FormattingUtils {
         i++;
       } else if (token is PlaceholderToken) {
         buffer.write('{${token.key}}');
+        i++;
+      } else if (token is HeadingToken) {
+        // Heading markers ('#' run) are stripped; the line's text content is
+        // emitted by the following TextTokens.
         i++;
       } else if (token is EscapeMarkerToken) {
         // Skip the backslash itself. The escaped character is always the

--- a/lib/src/editing/textf_span_builder.dart
+++ b/lib/src/editing/textf_span_builder.dart
@@ -240,7 +240,7 @@ class _SpanBuildState {
         endHeading();
         final marker = '${'#' * token.level}${' ' * (token.length - token.level)}';
         final headingStyle = resolver.resolveHeadingStyle(token.level, baseStyle);
-        emitMarker(marker, headingStyle.copyWith(color: activeMarkerStyle.color));
+        emitMarker(marker, headingMarkerStyle(i, headingStyle));
         _headingStyle = headingStyle;
         i++;
         continue;
@@ -536,6 +536,31 @@ class _SpanBuildState {
     final closeEnd = tokens[closeIndex].position + tokens[closeIndex].length;
     if (pos >= openPos && pos <= closeEnd) {
       return activeMarkerStyle;
+    }
+    return inactiveMarkerStyle;
+  }
+
+  /// Resolve heading marker style based on cursor position relative to line.
+  TextStyle headingMarkerStyle(int headingIndex, TextStyle headingStyle) {
+    final pos = cursorPosition;
+    if (pos == null) return headingStyle.copyWith(color: activeMarkerStyle.color);
+
+    final headingStart = tokens[headingIndex].position;
+    var headingEnd = headingStart + tokens[headingIndex].length;
+    for (var i = headingIndex + 1; i < tokens.length; i++) {
+      final token = tokens[i];
+      if (token is TextToken) {
+        final newlineIndex = token.value.indexOf('\n');
+        if (newlineIndex >= 0) {
+          headingEnd = token.position + newlineIndex;
+          break;
+        }
+      }
+      headingEnd = token.position + token.length;
+    }
+
+    if (pos >= headingStart && pos <= headingEnd) {
+      return headingStyle.copyWith(color: activeMarkerStyle.color);
     }
     return inactiveMarkerStyle;
   }

--- a/lib/src/editing/textf_span_builder.dart
+++ b/lib/src/editing/textf_span_builder.dart
@@ -183,6 +183,31 @@ class _SpanBuildState {
   final Set<int> scriptPairs = <int>{};
   final Set<int> scriptPreviewPairs = <int>{};
 
+  /// Active heading style when inside an ATX heading line, else null.
+  TextStyle? _headingStyle;
+
+  /// Begins a heading region for [level].
+  void beginHeading(int level) {
+    _headingStyle = resolver.resolveHeadingStyle(level, baseStyle);
+  }
+
+  /// Ends the active heading region.
+  void endHeading() {
+    _headingStyle = null;
+    var previousStyle = baseStyle;
+    for (var i = 0; i < formatStack.length; i++) {
+      final entry = formatStack[i];
+      final resolved = resolver.resolveStyle(entry.type, previousStyle);
+      formatStack[i] = FormatStackEntry(
+        index: entry.index,
+        matchingIndex: entry.matchingIndex,
+        type: entry.type,
+        resolvedStyle: resolved,
+      );
+      previousStyle = resolved;
+    }
+  }
+
   /// Main processing loop
   List<InlineSpan> build() {
     int i = 0;
@@ -207,6 +232,17 @@ class _SpanBuildState {
           continue;
         }
         // Not a valid link — fall through to plain text.
+      }
+
+      // Heading Handling (line-prefix ATX marker, scoped to end of line)
+      if (token is HeadingToken) {
+        flushText();
+        endHeading();
+        final marker = '${'#' * token.level}${' ' * (token.length - token.level)}';
+        emitMarker(marker, activeMarkerStyle);
+        beginHeading(token.level);
+        i++;
+        continue;
       }
 
       // Formatting Marker Handling
@@ -238,10 +274,7 @@ class _SpanBuildState {
             }
 
             // Compute resolved style at this stack depth for O(1) lookup.
-            final TextStyle previousStyle = formatStack.isEmpty //
-                ? baseStyle
-                : formatStack.last.resolvedStyle;
-            final TextStyle resolved = resolver.resolveStyle(token.markerType, previousStyle);
+            final TextStyle resolved = resolver.resolveStyle(token.markerType, currentStyle());
 
             formatStack.add(
               FormatStackEntry(
@@ -297,7 +330,7 @@ class _SpanBuildState {
       // Plain Text
       switch (token) {
         case TextToken(:final value):
-          textBuffer.write(value);
+          appendText(value);
         case FormatMarkerToken(:final value):
           textBuffer.write(value);
         case LinkStartToken():
@@ -308,6 +341,8 @@ class _SpanBuildState {
           textBuffer.write(')');
         case PlaceholderToken(:final key):
           textBuffer.write('{$key}');
+        case HeadingToken(:final level, :final length):
+          textBuffer.write('${'#' * level}${' ' * (length - level)}');
         case EscapeMarkerToken():
           flushText();
           final TextStyle style;
@@ -332,8 +367,29 @@ class _SpanBuildState {
   /// O(1) via cached [FormatStackEntry.resolvedStyle], falls back to
   /// walking the stack if entries lack cached styles.
   TextStyle currentStyle() {
-    if (formatStack.isEmpty) return baseStyle;
-    return formatStack.last.resolvedStyle;
+    if (formatStack.isNotEmpty) return formatStack.last.resolvedStyle;
+    return _headingStyle ?? baseStyle;
+  }
+
+  /// Appends text to the buffer, terminating an active heading at the first
+  /// newline (preserves the 1:1 character-slot invariant: every char, including
+  /// the newline, is still emitted exactly once via [flushText]).
+  void appendText(String value) {
+    if (_headingStyle == null) {
+      textBuffer.write(value);
+      return;
+    }
+    final int nl = value.indexOf('\n');
+    if (nl < 0) {
+      textBuffer.write(value);
+      return;
+    }
+    textBuffer.write(value.substring(0, nl + 1));
+    flushText();
+    endHeading();
+    if (nl + 1 < value.length) {
+      appendText(value.substring(nl + 1));
+    }
   }
 
   /// Check whether a script pair's MARKERS should be hidden

--- a/lib/src/editing/textf_span_builder.dart
+++ b/lib/src/editing/textf_span_builder.dart
@@ -239,8 +239,9 @@ class _SpanBuildState {
         flushText();
         endHeading();
         final marker = '${'#' * token.level}${' ' * (token.length - token.level)}';
-        emitMarker(marker, activeMarkerStyle);
-        beginHeading(token.level);
+        final headingStyle = resolver.resolveHeadingStyle(token.level, baseStyle);
+        emitMarker(marker, headingStyle.copyWith(color: activeMarkerStyle.color));
+        _headingStyle = headingStyle;
         i++;
         continue;
       }

--- a/lib/src/models/parser_state.dart
+++ b/lib/src/models/parser_state.dart
@@ -46,6 +46,11 @@ class ParserState {
   /// A stack tracking the currently active formatting markers.
   final List<FormatStackEntry> _formatStack = [];
 
+  /// The active heading style when inside an ATX heading line, else null.
+  ///
+  /// Cleared by [endHeading] (called when a newline or EOF terminates the line).
+  TextStyle? _headingStyle;
+
   /// An optional `TextScaler` for scaling the text.
   final TextScaler? textScaler;
 
@@ -91,14 +96,58 @@ class ParserState {
     _formatStack.removeLast();
   }
 
+  /// Begins a heading region for [level]. Subsequent text uses the heading
+  /// style until [endHeading] is called (at newline or EOF).
+  void beginHeading(int level) {
+    _headingStyle = styleResolver.resolveHeadingStyle(level, baseStyle);
+  }
+
+  /// Ends the active heading region.
+  void endHeading() {
+    _headingStyle = null;
+    var previousStyle = baseStyle;
+    for (var i = 0; i < _formatStack.length; i++) {
+      final entry = _formatStack[i];
+      final resolved = styleResolver.resolveStyle(entry.type, previousStyle);
+      _formatStack[i] = FormatStackEntry(
+        index: entry.index,
+        matchingIndex: entry.matchingIndex,
+        type: entry.type,
+        resolvedStyle: resolved,
+      );
+      previousStyle = resolved;
+    }
+  }
+
+  /// Appends text to the buffer, terminating an active heading at the first
+  /// newline (the newline and preceding text keep the heading style; anything
+  /// after resumes the base style).
+  void appendText(String value) {
+    if (_headingStyle == null) {
+      textBuffer.write(value);
+      return;
+    }
+    final int nl = value.indexOf('\n');
+    if (nl < 0) {
+      textBuffer.write(value);
+      return;
+    }
+    textBuffer.write(value.substring(0, nl + 1));
+    flushText();
+    endHeading();
+    if (nl + 1 < value.length) {
+      appendText(value.substring(nl + 1));
+    }
+  }
+
   /// Resolves the current style based on the format stack and base style.
   ///
   /// O(1): returns the pre-computed [FormatStackEntry.resolvedStyle] from the
-  /// stack top, or [baseStyle] when the stack is empty.
+  /// stack top, the active heading style (when the stack is empty inside a
+  /// heading line), or [baseStyle].
   TextStyle currentStyle() {
-    if (_formatStack.isEmpty) return baseStyle;
-
-    return _formatStack.last.resolvedStyle;
+    if (_formatStack.isNotEmpty) return _formatStack.last.resolvedStyle;
+    return _headingStyle ?? baseStyle;
   }
 
   /// Flushes the accumulated `textBuffer` as a `TextSpan` with the current formatting applied.

--- a/lib/src/models/textf_token.dart
+++ b/lib/src/models/textf_token.dart
@@ -137,3 +137,20 @@ final class EscapeMarkerToken extends TextfToken {
   @override
   String toString() => 'EscapeMarkerToken(at $position)';
 }
+
+/// An ATX-style heading prefix: a run of 1–6 `#` characters at the start of a
+/// line.
+///
+/// Unlike [FormatMarkerToken], a heading is a single-sided (line-prefix)
+/// marker: its style scopes from the end of this token to the next newline
+/// (or end of string). The heading level (1–6) is derived from the run length.
+final class HeadingToken extends TextfToken {
+  /// Creates a heading token.
+  const HeadingToken({required this.level, required super.position, required super.length});
+
+  /// The heading level, from 1 (`#`) to 6 (`######`).
+  final int level;
+
+  @override
+  String toString() => 'HeadingToken(h$level at $position)';
+}

--- a/lib/src/parsing/textf_parser.dart
+++ b/lib/src/parsing/textf_parser.dart
@@ -124,6 +124,16 @@ class TextfParser {
         continue;
       }
 
+      // Heading Handling (line-prefix ATX marker, scoped to end of line)
+      if (token is HeadingToken) {
+        state
+          ..flushText()
+          ..endHeading()
+          ..beginHeading(token.level);
+        i++;
+        continue;
+      }
+
       // Link Handling
       if (token is LinkStartToken) {
         // Attempt to process a link.
@@ -160,7 +170,7 @@ class TextfParser {
       // 3. Broken/Partial Link tokens
       switch (token) {
         case TextToken(:final value):
-          state.textBuffer.write(value);
+          state.appendText(value);
         case FormatMarkerToken(:final value):
           state.textBuffer.write(value);
         case LinkStartToken():
@@ -171,6 +181,8 @@ class TextfParser {
           state.textBuffer.write(')');
         case PlaceholderToken(:final key):
           state.textBuffer.write('{$key}');
+        case HeadingToken(:final level, :final length):
+          state.textBuffer.write('${'#' * level}${' ' * (length - level)}');
         case EscapeMarkerToken():
           // Do nothing. This effectively strips the '\' from the visual output.
           break;

--- a/lib/src/parsing/textf_tokenizer.dart
+++ b/lib/src/parsing/textf_tokenizer.dart
@@ -334,8 +334,7 @@ class TextfTokenizer {
           textStart = pos;
         }
       } else if (currentChar == kHash) {
-        final bool atLineStart =
-            pos == 0 || text.codeUnitAt(pos - 1) == kNewline;
+        final bool atLineStart = pos == 0 || text.codeUnitAt(pos - 1) == kNewline;
         if (atLineStart) {
           int count = 1;
           while (count < 6 && pos + count < length && text.codeUnitAt(pos + count) == kHash) {

--- a/lib/src/parsing/textf_tokenizer.dart
+++ b/lib/src/parsing/textf_tokenizer.dart
@@ -68,7 +68,8 @@ class TextfTokenizer {
             nextChar == kOpenParen ||
             nextChar == kCloseParen ||
             nextChar == kOpenBrace ||
-            nextChar == kCloseBrace) {
+            nextChar == kCloseBrace ||
+            nextChar == kHash) {
           addTextToken(textStart, pos);
           tokens
             // 1. Emit the backslash as a distinct marker token
@@ -331,6 +332,29 @@ class TextfTokenizer {
           tokens.add(TextToken('{', position: pos, length: 1));
           pos++;
           textStart = pos;
+        }
+      } else if (currentChar == kHash) {
+        final bool atLineStart =
+            pos == 0 || text.codeUnitAt(pos - 1) == kNewline;
+        if (atLineStart) {
+          int count = 1;
+          while (count < 6 && pos + count < length && text.codeUnitAt(pos + count) == kHash) {
+            count++;
+          }
+          var markerLength = count;
+          while (pos + markerLength < length && text.codeUnitAt(pos + markerLength) == 0x20) {
+            markerLength++;
+          }
+          if (markerLength == count) {
+            pos++;
+            continue;
+          }
+          addTextToken(textStart, pos);
+          tokens.add(HeadingToken(level: count, position: pos, length: markerLength));
+          pos += markerLength;
+          textStart = pos;
+        } else {
+          pos++;
         }
       } else {
         pos++;

--- a/lib/src/styling/textf_style_resolver.dart
+++ b/lib/src/styling/textf_style_resolver.dart
@@ -238,6 +238,29 @@ class TextfStyleResolver {
     );
   }
 
+  /// Resolves the final TextStyle for an ATX heading of [level] (1–6).
+  ///
+  /// Checks the matching `h{n}Style` in [TextfOptionsData] first, then falls
+  /// back to [DefaultStyles.headingStyle]. The result is merged onto
+  /// [baseStyle].
+  TextStyle resolveHeadingStyle(int level, TextStyle baseStyle) {
+    final opts = _options;
+    final TextStyle? optionsStyle = opts == null || level < 1 || level > 6
+        ? null
+        : <TextStyle?>[
+            opts.h1Style,
+            opts.h2Style,
+            opts.h3Style,
+            opts.h4Style,
+            opts.h5Style,
+            opts.h6Style,
+          ][level - 1];
+    if (optionsStyle != null) {
+      return mergeTextStyles(baseStyle, optionsStyle);
+    }
+    return DefaultStyles.headingStyle(level, baseStyle);
+  }
+
   // --- Private Helper Methods ---
 
   /// Internal helper to retrieve the pre-merged style from the TextfOptionsData.

--- a/lib/src/widgets/textf_options.dart
+++ b/lib/src/widgets/textf_options.dart
@@ -51,6 +51,12 @@ class TextfOptions extends StatelessWidget {
     this.superscriptBaselineFactor,
     this.subscriptBaselineFactor,
     this.scriptFontSizeFactor,
+    this.h1Style,
+    this.h2Style,
+    this.h3Style,
+    this.h4Style,
+    this.h5Style,
+    this.h6Style,
   });
 
   /// The child subtree that will have access to the merged TextfOptions configuration.
@@ -146,6 +152,24 @@ class TextfOptions extends StatelessWidget {
   /// Merged onto the base style if provided.
   final TextStyle? subscriptStyle;
 
+  /// The [TextStyle] for level-1 headings (`# H1`). Merged onto the base style.
+  final TextStyle? h1Style;
+
+  /// The [TextStyle] for level-2 headings (`## H2`). Merged onto the base style.
+  final TextStyle? h2Style;
+
+  /// The [TextStyle] for level-3 headings (`### H3`). Merged onto the base style.
+  final TextStyle? h3Style;
+
+  /// The [TextStyle] for level-4 headings (`#### H4`). Merged onto the base style.
+  final TextStyle? h4Style;
+
+  /// The [TextStyle] for level-5 headings (`##### H5`). Merged onto the base style.
+  final TextStyle? h5Style;
+
+  /// The [TextStyle] for level-6 headings (`###### H6`). Merged onto the base style.
+  final TextStyle? h6Style;
+
   /// Finds the nearest pre-merged [TextfOptionsData] ancestor in the widget tree.
   static TextfOptionsData? maybeOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<_TextfOptionsScope>()?.data;
@@ -218,6 +242,12 @@ class TextfOptions extends StatelessWidget {
       highlightStyle: _merge(parent?.highlightStyle, highlightStyle),
       superscriptStyle: _merge(parent?.superscriptStyle, superscriptStyle),
       subscriptStyle: _merge(parent?.subscriptStyle, subscriptStyle),
+      h1Style: _merge(parent?.h1Style, h1Style),
+      h2Style: _merge(parent?.h2Style, h2Style),
+      h3Style: _merge(parent?.h3Style, h3Style),
+      h4Style: _merge(parent?.h4Style, h4Style),
+      h5Style: _merge(parent?.h5Style, h5Style),
+      h6Style: _merge(parent?.h6Style, h6Style),
     );
 
     // 3. Provide the pre-merged O(1) object down the tree

--- a/lib/src/widgets/textf_options_data.dart
+++ b/lib/src/widgets/textf_options_data.dart
@@ -27,6 +27,12 @@ class TextfOptionsData {
     this.subscriptBaselineFactor,
     this.scriptFontSizeFactor,
     this.linkAlignment,
+    this.h1Style,
+    this.h2Style,
+    this.h3Style,
+    this.h4Style,
+    this.h5Style,
+    this.h6Style,
   });
 
   /// Callback function executed when tapping or clicking on a link.
@@ -115,6 +121,24 @@ class TextfOptionsData {
   /// Merged onto the base style if provided.
   final TextStyle? subscriptStyle;
 
+  /// The [TextStyle] for level-1 headings (`# H1`). Merged onto the base style.
+  final TextStyle? h1Style;
+
+  /// The [TextStyle] for level-2 headings (`## H2`). Merged onto the base style.
+  final TextStyle? h2Style;
+
+  /// The [TextStyle] for level-3 headings (`### H3`). Merged onto the base style.
+  final TextStyle? h3Style;
+
+  /// The [TextStyle] for level-4 headings (`#### H4`). Merged onto the base style.
+  final TextStyle? h4Style;
+
+  /// The [TextStyle] for level-5 headings (`##### H5`). Merged onto the base style.
+  final TextStyle? h5Style;
+
+  /// The [TextStyle] for level-6 headings (`###### H6`). Merged onto the base style.
+  final TextStyle? h6Style;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -137,7 +161,13 @@ class TextfOptionsData {
         other.underlineStyle == underlineStyle &&
         other.highlightStyle == highlightStyle &&
         other.superscriptStyle == superscriptStyle &&
-        other.subscriptStyle == subscriptStyle;
+        other.subscriptStyle == subscriptStyle &&
+        other.h1Style == h1Style &&
+        other.h2Style == h2Style &&
+        other.h3Style == h3Style &&
+        other.h4Style == h4Style &&
+        other.h5Style == h5Style &&
+        other.h6Style == h6Style;
   }
 
   @override
@@ -161,5 +191,11 @@ class TextfOptionsData {
         highlightStyle,
         superscriptStyle,
         subscriptStyle,
+        h1Style,
+        h2Style,
+        h3Style,
+        h4Style,
+        h5Style,
+        h6Style,
       ]);
 }

--- a/test/unit/editing/textf_span_builder_test.dart
+++ b/test/unit/editing/textf_span_builder_test.dart
@@ -72,6 +72,15 @@ void main() {
       });
     });
 
+    testWidgets('nested formatting keeps heading style', (tester) async {
+      await tester.pumpWidget(buildTestWidget(tester, (_) => Container()));
+      final spans = builder.build('# **Title**', testContext, const TextStyle(fontSize: 14));
+
+      final titleSpan = spans.whereType<TextSpan>().firstWhere((s) => s.text!.contains('Title'));
+      expect(titleSpan.style!.fontSize, 28.0);
+      expect(titleSpan.style!.fontWeight, FontWeight.bold);
+    });
+
     group('Character Count Invariant', () {
       testWidgets('bold text preserves character count', (tester) async {
         await tester.pumpWidget(buildTestWidget(tester, (_) => Container()));

--- a/test/unit/editing/textf_span_builder_test.dart
+++ b/test/unit/editing/textf_span_builder_test.dart
@@ -759,6 +759,22 @@ void main() {
         final bracketColor = spans.first.style?.color;
         expect(bracketColor!.a, greaterThan(0));
       });
+
+      testWidgets('heading marker hidden when cursor outside heading line', (tester) async {
+        await tester.pumpWidget(buildTestWidget(tester, (_) => Container()));
+        const baseStyle = TextStyle(color: Color(0xFF000000), fontSize: 14);
+        final spans = builder.build(
+          '#  Title\nbody',
+          testContext,
+          baseStyle,
+          cursorPosition: 10,
+        );
+
+        final markerSpan = spans.whereType<TextSpan>().first;
+        expect(markerSpan.text, '#  ');
+        expect(markerSpan.style!.color!.a, 0);
+        expect(markerSpan.style!.fontSize, lessThan(1));
+      });
     });
 
     // -----------------------------------------------------------------

--- a/test/unit/editing/textf_span_builder_test.dart
+++ b/test/unit/editing/textf_span_builder_test.dart
@@ -81,6 +81,15 @@ void main() {
       expect(titleSpan.style!.fontWeight, FontWeight.bold);
     });
 
+    testWidgets('heading marker uses heading size', (tester) async {
+      await tester.pumpWidget(buildTestWidget(tester, (_) => Container()));
+      final spans = builder.build('# Title', testContext, const TextStyle(fontSize: 14));
+
+      final markerSpan = spans.whereType<TextSpan>().first;
+      expect(markerSpan.text, '# ');
+      expect(markerSpan.style!.fontSize, 28.0);
+    });
+
     group('Character Count Invariant', () {
       testWidgets('bold text preserves character count', (tester) async {
         await tester.pumpWidget(buildTestWidget(tester, (_) => Container()));

--- a/test/unit/models/parser_state_test.dart
+++ b/test/unit/models/parser_state_test.dart
@@ -33,6 +33,9 @@ class _MockTextfStyleResolver implements TextfStyleResolver {
   // The remaining methods are not needed for this test and can be
   // implemented with an exception to ensure they are not accidentally called.
   @override
+  TextStyle resolveHeadingStyle(int level, TextStyle baseStyle) => throw UnimplementedError();
+
+  @override
   TextStyle resolveLinkStyle(TextStyle baseStyle) => throw UnimplementedError();
   @override
   TextStyle resolveLinkHoverStyle(TextStyle baseStyle) => throw UnimplementedError();

--- a/test/unit/parsing/heading_test.dart
+++ b/test/unit/parsing/heading_test.dart
@@ -1,0 +1,105 @@
+// ignore_for_file: no-magic-number, avoid-non-null-assertion
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:textf/src/core/formatting_utils.dart';
+import 'package:textf/src/models/textf_token.dart';
+import 'package:textf/src/parsing/textf_parser.dart';
+
+void main() {
+  group('ATX headings', () {
+    late TextfParser parser;
+
+    setUp(() {
+      TextfParser.clearCache();
+      parser = TextfParser();
+    });
+
+    Future<List<InlineSpan>> parse(WidgetTester tester, String text) async {
+      late List<InlineSpan> result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = parser.parse(text, context, const TextStyle(fontSize: 14));
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      return result;
+    }
+
+    testWidgets('H1 applies enlarged bold style to the line', (tester) async {
+      final result = await parse(tester, '# Title');
+
+      final textSpan = result.whereType<TextSpan>().firstWhere((s) => s.text!.contains('Title'));
+      expect(textSpan.style!.fontSize, 28.0);
+      expect(textSpan.style!.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('heading terminates at newline', (tester) async {
+      final result = await parse(tester, '# Heading\nbody');
+
+      final headingSpan = result.whereType<TextSpan>().firstWhere((s) => s.text!.contains('Heading'));
+      final bodySpan = result.whereType<TextSpan>().firstWhere((s) => s.text!.contains('body'));
+      expect(headingSpan.style!.fontSize, 28.0);
+      expect(bodySpan.style!.fontSize, 14.0);
+    });
+
+    testWidgets('heading terminates inside cross-line formatting', (tester) async {
+      final result = await parse(tester, '# **Heading\nbody**');
+
+      final headingSpan = result.whereType<TextSpan>().firstWhere((s) => s.text!.contains('Heading'));
+      final bodySpan = result.whereType<TextSpan>().firstWhere((s) => s.text!.contains('body'));
+      expect(headingSpan.style!.fontSize, 28.0);
+      expect(bodySpan.style!.fontSize, 14.0);
+      expect(bodySpan.style!.fontWeight, FontWeight.bold);
+    });
+
+    test('mid-line hash is not a heading', () {
+      final tokens = TextfParser.getCachedTokensAndPairs('use C# often').tokens;
+      expect(tokens.whereType<HeadingToken>(), isEmpty);
+    });
+
+    test('line-start hash without following space is not a heading', () {
+      final tokens = TextfParser.getCachedTokensAndPairs('#Title').tokens;
+      expect(tokens.whereType<HeadingToken>(), isEmpty);
+    });
+
+    test('escaped hash is literal text', () {
+      final tokens = TextfParser.getCachedTokensAndPairs(r'\# Heading').tokens;
+      expect(tokens.whereType<HeadingToken>(), isEmpty);
+      expect(tokens.whereType<TextToken>().map((t) => t.value).join(), '# Heading');
+    });
+
+    test('line-start hash emits a HeadingToken with correct level', () {
+      for (var level = 1; level <= 6; level++) {
+        TextfParser.clearCache();
+        final tokens = TextfParser.getCachedTokensAndPairs('${'#' * level} hi').tokens;
+        final heading = tokens.whereType<HeadingToken>().single;
+        expect(heading.level, level);
+        expect(heading.length, level + 1);
+      }
+    });
+
+    test('line-start hash consumes all following spaces as marker', () {
+      final tokens = TextfParser.getCachedTokensAndPairs('#   Title').tokens;
+      final heading = tokens.whereType<HeadingToken>().single;
+      expect(heading.level, 1);
+      expect(heading.length, 4);
+      expect(tokens.whereType<TextToken>().map((t) => t.value).join(), 'Title');
+    });
+
+    test('seven hashes is not a heading', () {
+      final tokens = TextfParser.getCachedTokensAndPairs('####### over').tokens;
+      expect(tokens.whereType<HeadingToken>(), isEmpty);
+    });
+
+    test('stripFormatting removes heading markers but keeps content', () {
+      expect(FormattingUtils.stripFormatting('# Title'), 'Title');
+      expect(FormattingUtils.stripFormatting('#   Title'), 'Title');
+      expect(FormattingUtils.stripFormatting('## Sub\nbody'), 'Sub\nbody');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add heading syntax and default/custom heading styles
- keep heading parsing consistent in read-only and editor rendering
- document editable heading line-height strut setup

## Checks
- dart analyze
- flutter test